### PR TITLE
Zero read fix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ impl Read for PipeReader {
         unsafe { copy_nonoverlapping(self.1.as_ptr(), buf.as_mut_ptr(), buf_len); }
         let buf = &mut buf[buf_len..];
 
-        if buf.len() == 0 {
+        if buf.is_empty() {
             return Ok(buf_len)
         }
 
@@ -135,7 +135,6 @@ mod tests {
 mod bench {
     extern crate test;
     use std::thread::spawn;
-    use std::io::{Read, Write};
     use self::test::Bencher;
     use super::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,32 @@ mod tests {
 
         guard.join().unwrap();
     }
+
+    #[test]
+    fn small_reads() {
+        let block_cnt = 20;
+        const BLOCK: usize = 20;
+        let (mut r, mut w) = pipe();
+        let guard = spawn(move || {
+            for _ in 0..block_cnt {
+                let data = &[0; BLOCK];
+                w.write_all(data).unwrap();
+            }
+        });
+
+        let mut buff = [0; BLOCK / 2];
+        let mut read = 0;
+        while let Ok(size) = r.read(&mut buff) {
+            // 0 means EOF
+            if size == 0 {
+                break;
+            }
+            read += size;
+        }
+        assert_eq!(block_cnt * BLOCK, read);
+
+        guard.join().unwrap();
+    }
 }
 
 #[cfg(all(test, feature = "bench"))]


### PR DESCRIPTION
Hello

I discovered the reader sometimes produces 0-sized reads in the middle of the stream (even when writes on the writer end are all non-0, but even if there were some 0-sized writes, it should not produce the 0-sized reads).

This is wrong, because 0-sized read (with non-empty buffer) means EOF, artificially „terminating“ the pipe too soon.

This adds a test for such a case and a fix.

Also, when hacking on the code, I did some little cleanups and removed all the unsafes, which are IMO unneeded in this case ‒ this code doesn't do anything fancy, nor FFI and the compiler should be smart enough to optimise the range-checks out by now (I haven't measured that, though).