### PR TITLE
Use crossbeam-channel for massive speedup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,23 @@ readme = "README.md"
 keywords = ["pipe", "synchronous", "read", "write"]
 license = "MIT"
 
+[lib]
+bench = false
+
+[[bench]]
+name = "pipe"
+harness = false
+
 [features]
 bench = []
 bidirectional = ["readwrite"]
 
 [dependencies]
 readwrite = {version = "0.1", optional = true}
+
+[dev-dependencies]
+criterion = "0.2"
+os_pipe = "0.8.1"
 
 [package.metadata.docs.rs]
 features = ["bidirectional"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ bench = []
 bidirectional = ["readwrite"]
 
 [dependencies]
+crossbeam-channel = "0.3.8"
 readwrite = {version = "0.1", optional = true}
 
 [dev-dependencies]

--- a/benches/pipe.rs
+++ b/benches/pipe.rs
@@ -1,0 +1,53 @@
+#[macro_use]
+extern crate criterion;
+extern crate os_pipe;
+extern crate pipe;
+
+use criterion::{black_box, Bencher, Criterion, ParameterizedBenchmark, Throughput};
+use std::convert::TryInto;
+use std::io::prelude::*;
+use std::thread;
+
+const TOTAL_TO_SEND: usize = 1 * 1024 * 1024;
+
+fn send_recv_size<F, R, W>(mut f: F) -> impl FnMut(&mut Bencher, &&usize)
+where
+    F: FnMut() -> (R, W),
+    F: Send + 'static,
+    R: Read + Send + 'static,
+    W: Write + Send + 'static,
+{
+    return move |b: &mut Bencher, &&size: &&usize| {
+        let f = &mut f;
+        let buf: Vec<u8> = (0..size).map(|i| i as u8).collect();
+        b.iter(move || {
+            let (mut reader, mut writer) = f();
+            let t = thread::spawn(move || {
+                let mut buf = vec![0; size];
+                while let Ok(_) = reader.read_exact(&mut buf) {}
+            });
+
+            for _ in 0..(TOTAL_TO_SEND / size) {
+                writer.write_all(black_box(&buf[..])).unwrap();
+            }
+            drop(writer);
+            t.join().expect("writing failed");
+        })
+    };
+}
+
+fn pipe_send(c: &mut Criterion) {
+    const KB: usize = 1024;
+    let bench = ParameterizedBenchmark::new(
+        "pipe-rs",
+        send_recv_size(|| pipe::pipe()),
+        &[4 * KB, 8 * KB, 16 * KB, 32 * KB, 64 * KB],
+    );
+    let bench = bench
+        .with_function("os_pipe", send_recv_size(|| os_pipe::pipe().unwrap()))
+        .throughput(|_| Throughput::Bytes(TOTAL_TO_SEND.try_into().unwrap()));
+    c.bench("pipe_send", bench);
+}
+
+criterion_group!(benches, pipe_send);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![deny(missing_docs)]
 #![doc(html_root_url = "http://arcnmx.github.io/pipe-rs/")]
-#![cfg_attr(all(feature = "bench", test), feature(test))]
 
 //! Synchronous in-memory pipe
 //!
@@ -159,35 +158,5 @@ mod tests {
         assert_eq!(block_cnt * BLOCK, read);
 
         guard.join().unwrap();
-    }
-}
-
-#[cfg(all(test, feature = "bench"))]
-mod bench {
-    extern crate test;
-    use std::thread::spawn;
-    use self::test::Bencher;
-    use super::*;
-
-    #[bench]
-    fn pipe_bench(b: &mut Bencher) {
-        use std::iter::repeat;
-        use std::io::{copy, sink};
-
-        let data = repeat(0).enumerate().map(|(i, _)| i as u8).take(0x1000).collect::<Vec<_>>();
-        b.bytes = data.len() as u64 * 0x100;
-        b.iter(|| {
-            let (mut r, mut w) = pipe();
-            let data = data.clone();
-            let guard = spawn(move || {
-                for _ in 0..0x100 {
-                    w.write_all(&data[..]).unwrap();
-                }
-            });
-
-            copy(&mut r, &mut sink()).unwrap();
-
-            guard.join().unwrap();
-        });
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,9 @@
 
 #[cfg(feature="readwrite")]
 extern crate readwrite;
+extern crate crossbeam_channel;
 
-use std::sync::mpsc::{sync_channel, SyncSender, Receiver};
+use crossbeam_channel::{Sender, Receiver};
 use std::io::{self, Read, Write};
 use std::cmp::min;
 
@@ -32,11 +33,11 @@ pub struct PipeReader(Receiver<Vec<u8>>, Vec<u8>);
 
 /// The `Write` end of a pipe (see `pipe()`)
 #[derive(Clone)]
-pub struct PipeWriter(SyncSender<Vec<u8>>);
+pub struct PipeWriter(Sender<Vec<u8>>);
 
 /// Creates a synchronous memory pipe
 pub fn pipe() -> (PipeReader, PipeWriter) {
-    let (tx, rx) = sync_channel(0);
+    let (tx, rx) = crossbeam_channel::bounded(0);
 
     (PipeReader(rx, Vec::new()), PipeWriter(tx))
 }
@@ -51,7 +52,7 @@ pub fn bipipe() -> (readwrite::ReadWrite<PipeReader, PipeWriter>, readwrite::Rea
 
 impl PipeWriter {
     /// Extracts the inner `SyncSender` from the writer
-    pub fn into_inner(self) -> SyncSender<Vec<u8>> {
+    pub fn into_inner(self) -> Sender<Vec<u8>> {
         self.0
     }
 }


### PR DESCRIPTION
Crossbeam-channel is apparently a lot better here.

**This introduces a breaking change**: the type of `into_inner` for `PipeReader`/`PipeWriter` is now crossbeam-channel's Sender/Reciever.

Also move benchmarks to criterion, to get some statistics on benchmarking, and to compare against `os_pipe` crate

## Performance results
```
pipe_send/pipe-rs/4096  time:   [582.11 us 592.09 us 603.99 us]
                        thrpt:  [1.6168 GiB/s 1.6493 GiB/s 1.6776 GiB/s]
                 change:
                        time:   [-94.119% -93.959% -93.763%] (p = 0.00 < 0.05)
                        thrpt:  [+1503.3% +1555.3% +1600.3%]
                        Performance has improved.
pipe_send/pipe-rs/8192  time:   [408.88 us 415.31 us 422.74 us]
                        thrpt:  [2.3101 GiB/s 2.3514 GiB/s 2.3884 GiB/s]
                 change:
                        time:   [-92.025% -91.820% -91.583%] (p = 0.00 < 0.05)
                        thrpt:  [+1088.1% +1122.5% +1153.9%]
                        Performance has improved.
pipe_send/pipe-rs/16384 time:   [332.98 us 341.16 us 349.94 us]
                        thrpt:  [2.7906 GiB/s 2.8625 GiB/s 2.9328 GiB/s]
                 change:
                        time:   [-87.484% -87.172% -86.865%] (p = 0.00 < 0.05)
                        thrpt:  [+661.32% +679.54% +698.97%]
                        Performance has improved.
pipe_send/pipe-rs/32768 time:   [291.44 us 296.80 us 303.01 us]
                        thrpt:  [3.2229 GiB/s 3.2903 GiB/s 3.3508 GiB/s]
                 change:
                        time:   [-79.435% -78.663% -77.785%] (p = 0.00 < 0.05)
                        thrpt:  [+350.14% +368.66% +386.27%]
                        Performance has improved.
pipe_send/pipe-rs/65536 time:   [282.22 us 288.76 us 295.90 us]
                        thrpt:  [3.3003 GiB/s 3.3819 GiB/s 3.4603 GiB/s]
                 change:
                        time:   [-63.272% -62.209% -60.964%] (p = 0.00 < 0.05)
                        thrpt:  [+156.17% +164.61% +172.27%]
                        Performance has improved.
```