### PR TITLE
Adds `PipeBufWriter` that buffers small writes

### DIFF
--- a/benches/pipe.rs
+++ b/benches/pipe.rs
@@ -38,14 +38,22 @@ where
 
 fn pipe_send(c: &mut Criterion) {
     const KB: usize = 1024;
-    const SIZES: &[usize] = &[4 * KB, 64 * KB];
-    //&[4 * KB, 8 * KB, 16 * KB, 32 * KB, 64 * KB],
+    //const SIZES: &[usize] = &[4 * KB, 64 * KB];
+    const SIZES: &[usize] = &[4 * KB, 8 * KB, 16 * KB, 32 * KB, 64 * KB];
 
     let bench = ParameterizedBenchmark::new( "pipe-rs", send_recv_size(|| pipe::pipe(), 1), SIZES)
         .throughput(|_| Throughput::Bytes(TOTAL_TO_SEND.try_into().unwrap()));
     c.bench("pipe_send", bench);
 
     let bench = ParameterizedBenchmark::new( "pipe-rs (16 reads per write)", send_recv_size(|| pipe::pipe(), 16), SIZES)
+        .throughput(|_| Throughput::Bytes(TOTAL_TO_SEND.try_into().unwrap()));
+    c.bench("pipe_send", bench);
+
+    let bench = ParameterizedBenchmark::new( "pipe-rs buffered", send_recv_size(|| pipe::pipe_buffered(), 1), SIZES)
+        .throughput(|_| Throughput::Bytes(TOTAL_TO_SEND.try_into().unwrap()));
+    c.bench("pipe_send", bench);
+
+    let bench = ParameterizedBenchmark::new( "pipe-rs buffered (16 reads per write)", send_recv_size(|| pipe::pipe_buffered(), 16), SIZES)
         .throughput(|_| Throughput::Bytes(TOTAL_TO_SEND.try_into().unwrap()));
     c.bench("pipe_send", bench);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,9 +25,13 @@
 extern crate readwrite;
 extern crate crossbeam_channel;
 
-use crossbeam_channel::{Sender, Receiver};
+use crossbeam_channel::{Sender, Receiver, TrySendError};
 use std::io::{self, BufRead, Read, Write};
 use std::cmp::min;
+use std::mem::swap;
+
+// value for libstd
+const DEFAULT_BUF_SIZE: usize = 8 * 1024;
 
 /// The `Read` end of a pipe (see `pipe()`)
 pub struct PipeReader {
@@ -40,11 +44,27 @@ pub struct PipeReader {
 #[derive(Clone)]
 pub struct PipeWriter(Sender<Vec<u8>>);
 
+/// The `Write` end of a pipe (see `pipe()`) that will buffer small writes before sending
+/// to the reader end.
+#[derive(Clone)]
+pub struct PipeBufWriter {
+    sender: Sender<Vec<u8>>,
+    buffer: Vec<u8>,
+    size: usize,
+}
+
 /// Creates a synchronous memory pipe
 pub fn pipe() -> (PipeReader, PipeWriter) {
     let (tx, rx) = crossbeam_channel::bounded(0);
 
     (PipeReader{ receiver: rx, buffer: Vec::new(), position: 0 }, PipeWriter(tx))
+}
+
+/// Creates a synchronous memory pipe with buffered writer
+pub fn pipe_buffered() -> (PipeReader, PipeBufWriter) {
+    let (tx, rx) = crossbeam_channel::bounded(0);
+
+    (PipeReader{ receiver: rx, buffer: Vec::new(), position: 0 }, PipeBufWriter { sender: tx, buffer: Vec::with_capacity(DEFAULT_BUF_SIZE), size: DEFAULT_BUF_SIZE } )
 }
 
 /// Creates a pair of pipes for bidirectional communication, a bit like UNIX's `socketpair(2)`.
@@ -56,10 +76,26 @@ pub fn bipipe() -> (readwrite::ReadWrite<PipeReader, PipeWriter>, readwrite::Rea
     ((r1,w2).into(), (r2,w1).into())
 }
 
+/// Creates a pair of pipes for bidirectional communication using buffered writer, a bit like UNIX's `socketpair(2)`.
+#[cfg(feature = "bidirectional")]
+#[cfg_attr(feature = "unstable-doc-cfg", doc(cfg(feature = "bidirectional")))]
+pub fn bipipe_buffered() -> (readwrite::ReadWrite<PipeReader, PipeBufWriter>, readwrite::ReadWrite<PipeReader, PipeBufWriter>) {
+    let (r1,w1) = pipe_buffered();
+    let (r2,w2) = pipe_buffered();
+    ((r1,w2).into(), (r2,w1).into())
+}
+
 impl PipeWriter {
     /// Extracts the inner `SyncSender` from the writer
     pub fn into_inner(self) -> Sender<Vec<u8>> {
         self.0
+    }
+}
+
+impl PipeBufWriter {
+    /// Extracts the inner `SyncSender` from the writer, and any pending buffered data
+    pub fn into_inner(self) -> (Sender<Vec<u8>>, Vec<u8>) {
+        (self.sender, self.buffer)
     }
 }
 
@@ -122,6 +158,43 @@ impl Write for PipeWriter {
     }
 }
 
+impl Write for PipeBufWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let bytes_written = if buf.len() > self.size {
+            // bypass buffering for big writes
+            buf.len()
+        } else {
+            // avoid resizing of the buffer
+            min(buf.len(), self.size - self.buffer.len())
+        };
+        self.buffer.extend_from_slice(&buf[..bytes_written]);
+
+        if self.buffer.len() >= self.size {
+            self.flush()?;
+        } else {
+            // reserve capacity later to avoid needless allocations
+            let mut data = Vec::new();
+            swap(&mut data, &mut self.buffer);
+
+            // buffer still has space but try to send it in case the other side already awaits
+            match self.sender.try_send(data) {
+                Ok(_) => self.buffer.reserve(self.size),
+                Err(TrySendError::Full(mut data)) => swap(&mut data, &mut self.buffer),
+                Err(TrySendError::Disconnected(_)) => return Err(io::Error::new(io::ErrorKind::BrokenPipe, "pipe reader has been dropped")),
+            }
+        }
+
+        Ok(bytes_written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        let mut data = Vec::with_capacity(self.size);
+        swap(&mut data, &mut self.buffer);
+        self.sender.send(data)
+            .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "pipe reader has been dropped"))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::thread::spawn;
@@ -168,6 +241,64 @@ mod tests {
                 let data = &[0; BLOCK];
                 w.write_all(data).unwrap();
             }
+        });
+
+        let mut buff = [0; BLOCK / 2];
+        let mut read = 0;
+        while let Ok(size) = r.read(&mut buff) {
+            // 0 means EOF
+            if size == 0 {
+                break;
+            }
+            read += size;
+        }
+        assert_eq!(block_cnt * BLOCK, read);
+
+        guard.join().unwrap();
+    }
+
+    #[test]
+    fn pipe_reader_buffered() {
+        let i = b"hello there";
+        let mut o = Vec::with_capacity(i.len());
+        let (mut r, mut w) = pipe_buffered();
+        let guard = spawn(move || {
+            w.write_all(&i[..5]).unwrap();
+            w.write_all(&i[5..]).unwrap();
+            w.flush().unwrap();
+            drop(w);
+        });
+
+        r.read_to_end(&mut o).unwrap();
+        assert_eq!(i, &o[..]);
+
+        guard.join().unwrap();
+    }
+
+    #[test]
+    fn pipe_writer_fail_buffered() {
+        let i = &[0; DEFAULT_BUF_SIZE * 2];
+        let (r, mut w) = pipe_buffered();
+        let guard = spawn(move || {
+            drop(r);
+        });
+
+        assert!(w.write_all(i).is_err());
+
+        guard.join().unwrap();
+    }
+
+    #[test]
+    fn small_reads_buffered() {
+        let block_cnt = 20;
+        const BLOCK: usize = 20;
+        let (mut r, mut w) = pipe_buffered();
+        let guard = spawn(move || {
+            for _ in 0..block_cnt {
+                let data = &[0; BLOCK];
+                w.write_all(data).unwrap();
+            }
+            w.flush().unwrap();
         });
 
         let mut buff = [0; BLOCK / 2];


### PR DESCRIPTION
This PR is based on my master branch and adds `PipeBufWriter` that buffers small writes. It will try to send out data after every write in non-blocking mode to avoid adding latency and will block when buffer is full. To preserve performance with writes bigger than the buffer it will fall back to blocking behavior of `PipeWriter`.

This improves performance for small writes but may concatenate written data and requires call to `.flush()` when done writing.

I have added benchmark for this and also for case when `PiperWriter` is wrapped in `BufWriter`. Apparently Rust does a good job in optimizing this as it is as fast if not faster than `PipeBufWriter` but it may add unnecessary latency in comparison as it does not to try to opportunistically send.