### PR TITLE
Cargo.toml: bump minor version of some crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,12 @@ bidirectional = ["readwrite"]
 unstable-doc-cfg = []
 
 [dependencies]
-crossbeam-channel = "^0.3.8"
+crossbeam-channel = "^0.4.0"
 readwrite = { version = "^0.1.1", optional = true }
 
 [dev-dependencies]
-criterion = "^0.2.11"
-os_pipe = "^0.8.1"
+criterion = "^0.3.0"
+os_pipe = "^0.9.0"
 
 [package.metadata.docs.rs]
 features = ["bidirectional", "unstable-doc-cfg"]


### PR DESCRIPTION
Bump the following crate dependencies:
- criterion from ^0.2.11 to ^0.3.0
- crossbeam-channel from ^0.3.8 to ^0.4.0
- os_pipe from ^0.8.1 to ^0.9.0

Context: Fedora currently includes versions of these crates at
these minor versions - this patch is needed to build `pipe` in
Fedora. Would like to upstream this patch here too.

Checking the changelogs, there do not appear to be breaking
changes that affect this crate (only an overall minimum toolchain
update to 1.31.0 and use of Rust "2018" edition). Tests passed
with `cargo test`.