### PR TITLE
Update crossbeam-channel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ bidirectional = ["readwrite"]
 unstable-doc-cfg = []
 
 [dependencies]
-crossbeam-channel = "^0.4.0"
+crossbeam-channel = "^0.5.0"
 readwrite = { version = "^0.1.1", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Hey we're using `pipe` in [EmbarkStudios/rust-gpu](https://github.com/EmbarkStudios/rust-gpu) and I noticed that we had some duplicate dependencies since `pipe` depends on an old version of crossbeam-channel that depends on a pre 1.0 version of `log`. This just updates crossbeam-channel to fix that.